### PR TITLE
Update class-wc-iugu-pix-gateway.php

### DIFF
--- a/inc/gateways/pix/class-wc-iugu-pix-gateway.php
+++ b/inc/gateways/pix/class-wc-iugu-pix-gateway.php
@@ -40,7 +40,7 @@ class WC_Iugu_Pix_Gateway2 extends WC_Iugu_Woocommerce_Subscription_Gateway {
 		/**
 		 * Handles notification requets from the API.
 		 */
-		add_action('woocommerce_api_wc_iugu_pix_gateway', array($this, 'notification_handler'));
+		add_action('woocommerce_api_wc_iugu_pix_gateway2', array($this, 'notification_handler'));
 		/**
 		 * Adds the gateways settings.
 		 */


### PR DESCRIPTION
Callback está errado, o link que a iugu manda o IPN é "/wc-api/WC_lugu_Pix_Gateway2/" mas o woocommerce_api_wc_iugu_pix_gateway <-- assim o woocommerce não recebe as confirmações de pagamento, fiz vários testes, após colocar o 2 no final, voltou a funcionar normalmente.... 

Doc: https://woocommerce.com/document/wc_api-the-woocommerce-api-callback/